### PR TITLE
Some small fixes

### DIFF
--- a/linux-local-enum.sh
+++ b/linux-local-enum.sh
@@ -108,7 +108,7 @@ printf "\n"
 printf "\n"
 /bin/cat /etc/sysconfig/network-scripts/ifcfg-eth0
 printf "\n"
-/sbin/ip
+/sbin/ip a
 printf "\n"
 /sbin/ifconfig
 printf "\n"
@@ -327,7 +327,7 @@ printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' '#'
 printf "##"
 printf "\n"
 printf "$red"
-printf "$blue## $red World Writable FIles"
+printf "$blue## $red World Writable Files"
 printf "\n"
 printf "$blue"
 printf "##"
@@ -423,7 +423,7 @@ printf "\n"
 printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' '#'
 printf "\n"
 printf "$reset"
-/bin/ps -ef | /bin/grep root
+/bin/ps -ef | /bin/grep [r]oot
 
 
 printf "\n"

--- a/linux-local-enum.sh
+++ b/linux-local-enum.sh
@@ -423,7 +423,7 @@ printf "\n"
 printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' '#'
 printf "\n"
 printf "$reset"
-/bin/ps -ef | /bin/grep [r]oot
+/bin/ps -ef | /bin/grep "[r]oot"
 
 
 printf "\n"


### PR DESCRIPTION
Thanks for your script! Helped me a lot. In this PR a few small fixes:
- /sbin/ip isn't a valid command, added the "a" flag
- Typo
- Trick to prevent grep from being shown under processes (https://serverfault.com/questions/367921/how-to-prevent-ps-reporting-its-own-process)

